### PR TITLE
Fix: Ensure consistent width for all section titles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -148,7 +148,7 @@ function ResultsScroller({ results }) {
 
   return (
     <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-      <h2 className="section-title">Results by Team</h2>
+      <h2 className="section-title" style={{ width: '100%' }}>Results by Team</h2>
       {/* Team selection horizontal row */}
       <div style={{ marginBottom: '1.5rem', display: 'flex', flexDirection: 'row', justifyContent: 'center', flexWrap: 'wrap', gap: 12, width: '100%' }}>
         {teams.map(team => (


### PR DESCRIPTION
The section title "Results by Team" within the ResultsScroller component was previously not spanning the full width of its container due to the parent being a flex container with `align-items: center`.

This change adds `style={{ width: '100%' }}` to the `h2.section-title` in `ResultsScroller` to ensure it takes the full available width, making it consistent with other section titles on the site (e.g., "Upcoming Schedule", "Latest Results", "Standings").

All section titles now consistently span the width of the main content area.